### PR TITLE
Changed how documents are drawn

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -9,6 +9,10 @@ on:
     types:
       - created
 
+concurrency:
+  group: ${{ github.workflow }}|${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: "Build GDExtension"

--- a/project/test.tscn
+++ b/project/test.tscn
@@ -56,7 +56,6 @@ size_flags_horizontal = 3
 script = ExtResource("1_37kl0")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="hbox"]
-visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 

--- a/src/element/rml_document.cpp
+++ b/src/element/rml_document.cpp
@@ -26,6 +26,10 @@ void RMLDocument::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_PROCESS: {
 			update();
+			queue_redraw();
+		} break;
+		case NOTIFICATION_DRAW: {
+			RMLServer::get_singleton()->document_draw(rid, get_canvas_item());
 		} break;
 		case NOTIFICATION_RESIZED: {
 			RMLServer::get_singleton()->document_set_size(rid, Vector2i(
@@ -57,7 +61,7 @@ void RMLDocument::new_document() {
 	if (rid.is_valid()) {
 		RMLServer::get_singleton()->free_rid(rid);
 	}
-	rid = RMLServer::get_singleton()->create_document(get_canvas_item());
+	rid = RMLServer::get_singleton()->create_document();
 	RMLServer::get_singleton()->document_set_size(rid, get_size());
 }
 
@@ -65,7 +69,7 @@ void RMLDocument::load_from_rml_string(const String &p_rml) {
 	if (rid.is_valid()) {
 		RMLServer::get_singleton()->free_rid(rid);
 	}
-	rid = RMLServer::get_singleton()->create_document_from_rml_string(get_canvas_item(), p_rml);
+	rid = RMLServer::get_singleton()->create_document_from_rml_string(p_rml);
 	RMLServer::get_singleton()->document_set_size(rid, get_size());
 }
 
@@ -73,7 +77,7 @@ void RMLDocument::load_from_path(const String &p_path) {
 	if (rid.is_valid()) {
 		RMLServer::get_singleton()->free_rid(rid);
 	}
-	rid = RMLServer::get_singleton()->create_document_from_path(get_canvas_item(), p_path);
+	rid = RMLServer::get_singleton()->create_document_from_path(p_path);
 	RMLServer::get_singleton()->document_set_size(rid, get_size());
 }
 

--- a/src/interface/render_interface_godot.cpp
+++ b/src/interface/render_interface_godot.cpp
@@ -403,6 +403,25 @@ void RenderInterfaceGodot::allocate_render_frame() {
     target_frame->main_tex = rs->texture_rd_create(target_frame->main_target.color0);
 }
 
+void RenderInterfaceGodot::free_render_frame(RenderFrame *p_frame) {
+    RenderingServer *rs = RenderingServer::get_singleton();
+    
+    free_render_target(&p_frame->main_target);
+    free_render_target(&p_frame->primary_filter_target);
+    free_render_target(&p_frame->secondary_filter_target);
+    free_render_target(&p_frame->blend_mask_target);
+    
+    if (p_frame->clip_mask_framebuffer.is_valid()) {
+        rendering_resources.free_framebuffer(p_frame->clip_mask_framebuffer);
+    }
+    if (p_frame->clip_mask.is_valid()) {
+        rendering_resources.free_texture(p_frame->clip_mask);
+    }
+    if (p_frame->main_tex.is_valid()) {
+        rs->free_rid(p_frame->main_tex);
+    }
+}
+
 void RenderInterfaceGodot::blit_texture(const RID &p_dst, const RID &p_src, const Vector2i &p_dst_pos, const Vector2i &p_src_pos, const Vector2i &p_size) {
     RD *rd = internal_rendering_resources.device();
 
@@ -428,22 +447,6 @@ void RenderInterfaceGodot::blit_texture(const RID &p_dst, const RID &p_src, cons
 
     rd->draw_list_draw(draw_list, false, 1, 3);
     rd->draw_list_end();
-}
-
-void RenderInterfaceGodot::free_render_frame(RenderFrame *p_frame) {
-    RenderingServer *rs = RenderingServer::get_singleton();
-
-    free_render_target(&p_frame->main_target);
-    free_render_target(&p_frame->primary_filter_target);
-    free_render_target(&p_frame->secondary_filter_target);
-    free_render_target(&p_frame->blend_mask_target);
-
-    if (p_frame->clip_mask_framebuffer.is_valid()) {
-        rendering_resources.free_framebuffer(p_frame->clip_mask_framebuffer);
-    }
-    if (p_frame->clip_mask.is_valid()) {
-        rendering_resources.free_texture(p_frame->clip_mask);
-    }
 }
 
 void RenderInterfaceGodot::set_render_frame(RenderFrame *p_frame) {

--- a/src/server/rml_server.h
+++ b/src/server/rml_server.h
@@ -25,17 +25,13 @@ class RMLServer: public Object {
 	struct DocumentData {
 		Rml::Context *ctx;
 		Rml::ElementDocument *doc;
-		RID canvas_item;
 		RenderFrame *render_frame;
 		Input::CursorShape cursor_shape = Input::CURSOR_ARROW;
 	};
 
 	RID_Owner<DocumentData> document_owner;
 
-	void render();
-
-	RID initialize_document(const RID &p_canvas_item);
-	void free_render_frame(uint64_t p_frame);
+	RID initialize_document();
 protected:
 	static void _bind_methods();
 	
@@ -46,9 +42,9 @@ public:
 	void initialize();
 	void uninitialize();
 
-	RID create_document(const RID &p_canvas_item);
-	RID create_document_from_rml_string(const RID &p_canvas_item, const String &p_string);
-	RID create_document_from_path(const RID &p_canvas_item, const String &p_path);
+	RID create_document();
+	RID create_document_from_rml_string(const String &p_string);
+	RID create_document_from_path(const String &p_path);
 	Ref<RMLElement> get_document_root(const RID &p_document);
 	Ref<RMLElement> create_element(const RID &p_document, const String &p_tag_name);
 
@@ -57,6 +53,7 @@ public:
 	bool document_process_event(const RID &p_document, const Ref<InputEvent> &p_event);
 	void document_set_cursor_shape(const RID &p_document, const Input::CursorShape &p_shape);
 	Input::CursorShape document_get_cursor_shape(const RID &p_document);
+	void document_draw(const RID &p_document, const RID &p_canvas_item);
 
 	bool load_default_stylesheet(const String &p_path);
 


### PR DESCRIPTION
Previously, creating documents using `RMLServer` needed to pass a `CanvasItem`'s `RID`. For each document, it automatically cleared the `CanvasItem` and drawed the document's render target texture.

Now, documents created on `RMLServer` doesn't have a reference to a `CanvasItem`, instead `RMLDocument` draws the document through R`MLServer.document_draw(canvas_item: RID)` on `NOTIFICATION_DRAW`.

Also fixed some memory leakage related to texture creation.