### PR TITLE
Improved element reference

### DIFF
--- a/project/test.gd
+++ b/project/test.gd
@@ -3,3 +3,14 @@ extends RMLDocument
 func _ready() -> void:
 	load_from_path("res://test.rml")
 	
+	var doc: RMLElement = as_element()
+	var el: RMLElement = create_element("div")
+	doc.append_child(el)
+	
+	await get_tree().create_timer(1.0).timeout
+	
+	el.set_text_content("Test reference")
+	
+	await get_tree().create_timer(1.0).timeout
+	
+	doc.remove_child(el)

--- a/src/element/rml_element.cpp
+++ b/src/element/rml_element.cpp
@@ -22,8 +22,7 @@ void RMLElement::append_child(const Ref<RMLElement> &p_child) {
 	ENSURE_VALID(p_child);
 	ERR_FAIL_COND(p_child->element->GetParentNode() != nullptr);
 	
-	Rml::Element *el = element->AppendChild(p_child->element.pop_owned());
-	p_child->element.attached = el;
+	element->AppendChild(p_child->element.pop_owned());
 }
 
 void RMLElement::remove_child(const Ref<RMLElement> &p_child) {
@@ -31,8 +30,8 @@ void RMLElement::remove_child(const Ref<RMLElement> &p_child) {
 	ENSURE_VALID(p_child);
 	ERR_FAIL_COND(p_child->element->GetParentNode() != element.get());
 
-	Rml::ElementPtr el = element->RemoveChild(p_child->element.pop_attached());
-	p_child->element.owned = std::move(el);
+	Rml::ElementPtr el = element->RemoveChild(p_child->element.get());
+	p_child->element.push_owner(std::move(el));
 }
 
 Ref<RMLElement> RMLElement::query_selector(const String &p_selector) const {
@@ -256,10 +255,17 @@ Ref<RMLElement> RMLElement::ref(ElementRef &ref) {
 	return ret;
 }
 
-Ref<RMLElement> RMLElement::ref(ElementRef &&ref) {
+Ref<RMLElement> RMLElement::ref(Rml::ElementPtr &&el) {
 	Ref<RMLElement> ret;
 	ret.instantiate();
-	ret->element = ref;
+	ret->element = ElementRef(std::move(el));
+	return ret;
+}
+
+Ref<RMLElement> RMLElement::ref(Rml::Element *el) {
+	Ref<RMLElement> ret;
+	ret.instantiate();
+	ret->element = ElementRef(el);
 	return ret;
 }
 

--- a/src/element/rml_element.h
+++ b/src/element/rml_element.h
@@ -3,70 +3,12 @@
 #include <godot_cpp/classes/ref_counted.hpp>
 #include <RmlUi/Core.h>
 
+#include "rml_element_ref.h"
+
 namespace godot {
 
 class RMLServer;
 class RMLDocument;
-
-using element_ptr = Rml::ElementPtr;
-
-struct ElementRef {
-	element_ptr owned;
-	Rml::Element *attached = nullptr;
-
-	Rml::Element *get() const {
-		return attached ? attached : owned.get();
-	}
-
-	bool is_attached() const {
-		return attached != nullptr;
-	}
-
-	bool is_valid() const {
-		return get() != nullptr;
-	}
-
-	element_ptr pop_owned() {
-		element_ptr ptr = std::move(owned);
-		owned = nullptr;
-		return ptr;
-	}
-
-	Rml::Element *pop_attached() {
-		Rml::Element *ptr = attached;
-		attached = nullptr;
-		return ptr;
-	}
-
-	_FORCE_INLINE_ void operator=(ElementRef &p_ref) {
-		owned = p_ref.pop_owned();
-		attached = p_ref.attached;
-	}
-
-	_FORCE_INLINE_ bool operator==(const Rml::Element *p_ptr) const {
-		return get() == p_ptr;
-	}
-
-	_FORCE_INLINE_ Rml::Element *operator*() const {
-		return get();
-	}
-
-	_FORCE_INLINE_ Rml::Element *operator->() const {
-		return get();
-	}
-
-	_FORCE_INLINE_ Rml::Element *ptr() const {
-		return get();
-	}
-
-	_FORCE_INLINE_ ElementRef() {}
-	_FORCE_INLINE_ ElementRef(ElementRef &ref) {
-		owned = ref.pop_owned();
-		attached = ref.attached;
-	}
-	_FORCE_INLINE_ ElementRef(Rml::Element *el): attached(el) {}
-	_FORCE_INLINE_ ElementRef(Rml::ElementPtr el): owned(std::move(el)) {}
-};
 
 class RMLElement: public RefCounted {
 	GDCLASS(RMLElement, RefCounted);
@@ -126,7 +68,8 @@ public:
 	Rml::Element *get_element() const;
 
 	static Ref<RMLElement> ref(ElementRef &ref);
-	static Ref<RMLElement> ref(ElementRef &&ref);
+	static Ref<RMLElement> ref(Rml::ElementPtr &&el);
+	static Ref<RMLElement> ref(Rml::Element *el);
 	static Ref<RMLElement> empty();
 
 	RMLElement(): element(nullptr) {}

--- a/src/element/rml_element_ref.cpp
+++ b/src/element/rml_element_ref.cpp
@@ -1,0 +1,111 @@
+#include "rml_element_ref.h"
+
+using namespace godot;
+
+std::map<Rml::Element *, std::weak_ptr<ElementOwner>> ElementOwner::owners = {};
+
+Rml::Element *ElementOwner::get() const {
+	return ptr;
+}
+
+bool ElementOwner::is_unique() const {
+	return unique_ptr != nullptr;
+}
+
+Rml::ElementPtr ElementOwner::pop_owned() {
+	ERR_FAIL_NULL_V(unique_ptr, nullptr);
+	Rml::ElementPtr ret = std::move(unique_ptr);
+	unique_ptr = nullptr;
+	return ret;
+}
+
+void ElementOwner::push_owned(Rml::ElementPtr &&p_ptr) {
+	unique_ptr = std::move(p_ptr);
+	ptr = unique_ptr.get();
+}
+
+void ElementOwner::push_raw(Rml::Element *p_ptr) {
+	unique_ptr = nullptr;
+	ptr = p_ptr;
+}
+
+ElementOwner::ElementOwner(Rml::ElementPtr &&ptr) {
+	push_owned(std::move(ptr));
+}
+
+ElementOwner::ElementOwner(Rml::Element *ptr) {
+	push_raw(ptr);
+}
+
+ElementOwner::~ElementOwner() { }
+
+std::shared_ptr<ElementOwner> ElementOwner::map(Rml::ElementPtr &&p_ptr) {
+	std::shared_ptr<ElementOwner> owner = map(p_ptr.get());
+	if (owner == nullptr) return nullptr;
+	owner->push_owned(std::move(p_ptr));
+	return owner;
+}
+
+std::shared_ptr<ElementOwner> ElementOwner::map(Rml::Element *p_ptr) {
+	if (p_ptr == nullptr) return nullptr;
+	auto it = owners.find(p_ptr);
+	if (it != owners.end()) {
+		std::shared_ptr<ElementOwner> owner = it->second.lock();
+		if (owner) {
+			return owner;
+		}
+	}
+	std::shared_ptr<ElementOwner> owner = std::make_unique<ElementOwner>(p_ptr);
+	owners.insert({ p_ptr, owner });
+	return owner;
+}
+
+Rml::Element *ElementRef::get() const {
+	return owner ? owner->get() : nullptr;
+}
+
+bool ElementRef::is_valid() const {
+	return owner != nullptr;
+}
+
+Rml::ElementPtr ElementRef::pop_owned() {
+	ERR_FAIL_NULL_V(owner, nullptr);
+	return owner->pop_owned();
+}
+
+void ElementRef::push_owner(Rml::ElementPtr &&p_ptr) {
+	ERR_FAIL_NULL(owner);
+	owner->push_owned(std::move(p_ptr));
+}
+
+bool ElementRef::operator==(const Rml::Element *p_ptr) const {
+	return get() == p_ptr;
+}
+
+bool ElementRef::operator==(const ElementRef &p_ref) const {
+	return get() == p_ref.get();
+}
+
+Rml::Element *ElementRef::operator*() const {
+	return get();
+}
+
+Rml::Element *ElementRef::operator->() const {
+	return get();
+}
+
+ElementRef::ElementRef() { }
+
+ElementRef::ElementRef(ElementRef &ref) {
+	owner = ref.owner;
+}
+
+ElementRef::ElementRef(Rml::Element *el) {
+	owner = ElementOwner::map(el);
+}
+
+ElementRef::ElementRef(Rml::ElementPtr &&el) {
+	owner = ElementOwner::map(std::move(el));
+}
+
+

--- a/src/element/rml_element_ref.h
+++ b/src/element/rml_element_ref.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <godot_cpp/core/error_macros.hpp>
+#include <RmlUi/Core.h>
+
+namespace godot {
+
+// Owns a unique pointer or a raw pointer to a Rml::Element
+// Must always point to a valid element
+class ElementOwner {
+private:
+	static std::map<Rml::Element *, std::weak_ptr<ElementOwner>> owners;
+
+	Rml::ElementPtr unique_ptr = nullptr;
+	Rml::Element *ptr = nullptr;
+
+public:
+	Rml::Element *get() const;
+	bool is_unique() const;
+	
+	Rml::ElementPtr pop_owned();
+
+	void push_owned(Rml::ElementPtr &&p_ptr);
+	void push_raw(Rml::Element *p_ptr);
+
+	static std::shared_ptr<ElementOwner> map(Rml::ElementPtr &&p_ptr);
+	static std::shared_ptr<ElementOwner> map(Rml::Element *p_ptr);
+
+	ElementOwner(Rml::ElementPtr &&ptr);
+	ElementOwner(Rml::Element *ptr);
+	~ElementOwner();
+};
+
+class ElementRef {
+private:
+	std::shared_ptr<ElementOwner> owner = nullptr;
+
+public:
+	Rml::Element *get() const;
+	bool is_valid() const;
+
+	Rml::ElementPtr pop_owned();
+	void push_owner(Rml::ElementPtr &&p_ptr);
+
+	bool operator==(const Rml::Element *p_ptr) const;
+	bool operator==(const ElementRef &p_ref) const;
+
+	Rml::Element *operator*() const;
+	Rml::Element *operator->() const;
+
+	ElementRef();
+	ElementRef(ElementRef &ref);
+	ElementRef(Rml::Element *el);
+	ElementRef(Rml::ElementPtr &&el);
+};
+
+};


### PR DESCRIPTION
Improved element reference using a single owner per element pointer, accessing the reference using a shared_ptr of the owner.

Meaning multiple instances of RMLElement references the same owner which references the same element.
Previously, multiple instances of RMLElement directly referenced the same element, but wasn't updating the element pointer whenever it changes from unique_ptr to a raw pointer in all instances, leading to potential element freeing when there is still references.

This changes enables more safer element references and lifetime.